### PR TITLE
fix: Add missing `types` key to package entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "exports": {
     ".": {
       "browser": "./src/index.browser.js",
-      "import": "./src/index.js"
+      "import": "./src/index.js",
+      "types": "./types/index.d.ts"
     }
   },
   "dependencies": {


### PR DESCRIPTION
Otherwise, TypeScript cannot find types when this package is imported under `"moduleResolution": "Node16"`.